### PR TITLE
feature: add response_headers_policy_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ resource "aws_cloudfront_distribution" "this" {
         for_each = length(lookup(origin.value, "origin_shield", "")) == 0 ? [] : [lookup(origin.value, "origin_shield", "")]
 
         content {
-          enabled = origin_shield.value.enabled
+          enabled              = origin_shield.value.enabled
           origin_shield_region = origin_shield.value.origin_shield_region
         }
       }
@@ -177,8 +177,9 @@ resource "aws_cloudfront_distribution" "this" {
       trusted_signers           = lookup(i.value, "trusted_signers", null)
       trusted_key_groups        = lookup(i.value, "trusted_key_groups", null)
 
-      cache_policy_id          = lookup(i.value, "cache_policy_id", null)
-      origin_request_policy_id = lookup(i.value, "origin_request_policy_id", null)
+      cache_policy_id            = lookup(i.value, "cache_policy_id", null)
+      origin_request_policy_id   = lookup(i.value, "origin_request_policy_id", null)
+      response_headers_policy_id = lookup(i.value, "response_headers_policy_id", null)
 
       min_ttl     = lookup(i.value, "min_ttl", null)
       default_ttl = lookup(i.value, "default_ttl", null)


### PR DESCRIPTION
Add ability to set [`response_headers_policy_id` ](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#response_headers_policy_id)