### PR TITLE
feature: add resp hdr policy id option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -115,8 +115,9 @@ resource "aws_cloudfront_distribution" "this" {
       trusted_signers           = lookup(i.value, "trusted_signers", null)
       trusted_key_groups        = lookup(i.value, "trusted_key_groups", null)
 
-      cache_policy_id          = lookup(i.value, "cache_policy_id", null)
-      origin_request_policy_id = lookup(i.value, "origin_request_policy_id", null)
+      cache_policy_id            = lookup(i.value, "cache_policy_id", null)
+      origin_request_policy_id   = lookup(i.value, "origin_request_policy_id", null)
+      response_headers_policy_id = lookup(i.value, "response_headers_policy_id", null)
 
       min_ttl     = lookup(i.value, "min_ttl", null)
       default_ttl = lookup(i.value, "default_ttl", null)


### PR DESCRIPTION
Only added `response_header_policy_id` to _ordered_ cache behaviors in #1 , adding to _default_ cache behavior.